### PR TITLE
Fix repository name to lower case in buildspec.yml

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,7 @@ phases:
   pre_build:
     commands:
       - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
-      - REPO=$(aws ecr describe-repositories --repository-names ToeBeans --output text --query "repositories[0].repositoryUri")
+      - REPO=$(aws ecr describe-repositories --repository-names toebeans --output text --query "repositories[0].repositoryUri")
       - IMAGE=$REPO:latest
   build:
     commands:


### PR DESCRIPTION
`An error occurred (InvalidParameterException) when calling the DescribeRepositories operation: Invalid parameter at 'repositoryName' failed to satisfy constraint: 'must satisfy regular expression '(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*''`