### PR TITLE
GCPのサービスアカウント情報の参照方法の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,22 @@ This is written in Japanese.
   - 1000リクエスト/月まで無料
   - 500万リクエスト/月まで1.5$
   - https://cloud.google.com/vision/pricing
+
+#  Launch in local
+## Backend
+投稿機能を使用する場合は、 `docker-compose.yml` の `GOOGLE_API_KEY` を設定する。値はSSMのパラメータストアに設定されている。
+
+```
+$ cd backend
+$ ./serverrun.sh
+# go run main.go
+```
+
+## Frontend
+```
+$ npm install
+$ npm start
+```
+
+## Browser
+Access to `localhost:3000/login` .

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,6 +46,6 @@ WORKDIR /go/src/github.com/gold-kou/ToeBeans/backend
 COPY config/logger.yml.tpl config/logger.yml.tpl
 WORKDIR /
 COPY --from=builder /go/src/github.com/gold-kou/ToeBeans/backend/backend /backend
-ENV TZ=Asia/Tokyo DB_NAME=toebeansdb DB_USER=toebeans DB_HOST=db DB_PORT=3306 GOOGLE_APPLICATION_CREDENTIALS=secret/service-account.json SYSTEM_EMAIL=no-reply@toebeans.tk S3_BUCKET_POSTINGS=/toebeans-postings S3_BUCKET_ICONS=/toebeans-icons APP_ENV=prd LOG_LEVEL=info JWT_SECRET_KEY=samplekey DB_PASSWORD=secret DB_HOST=db-test AWS_ACCESS_KEY=test_access_key AWS_SECRET_KEY=test_secret_key AWS_REGION=ap-​northeast-1
+ENV TZ=Asia/Tokyo DB_NAME=toebeansdb DB_USER=toebeans DB_HOST=db DB_PORT=3306 GOOGLE_API_KEY=XXXXX SYSTEM_EMAIL=no-reply@toebeans.tk S3_BUCKET_POSTINGS=/toebeans-postings S3_BUCKET_ICONS=/toebeans-icons APP_ENV=prd LOG_LEVEL=info JWT_SECRET_KEY=samplekey DB_PASSWORD=secret DB_HOST=db-test AWS_ACCESS_KEY=test_access_key AWS_SECRET_KEY=test_secret_key AWS_REGION=ap-​northeast-1
 EXPOSE 80
 CMD ["/backend"]

--- a/backend/app/adapter/gcp/cloud_vision_api.go
+++ b/backend/app/adapter/gcp/cloud_vision_api.go
@@ -4,19 +4,20 @@ import (
 	"context"
 	"os"
 
-	"github.com/pkg/errors"
-
 	vision "cloud.google.com/go/vision/apiv1"
+	"github.com/pkg/errors"
+	"google.golang.org/api/option"
 )
 
 // DetectLabels gets labels from the Vision API for an image at the given file path.
 func DetectLabels(file string) (labels []string, err error) {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx, option.WithCredentialsJSON([]byte(os.Getenv("GOOGLE_API_KEY"))))
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	f, err := os.Open(file)
 	if err != nil {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - DB_PASSWORD=secret
       - DB_HOST=db
       - DB_PORT=3306
-      - GOOGLE_APPLICATION_CREDENTIALS=secret/service-account.json
+      - GOOGLE_API_KEY=test_google_api_key # must not be real key
       - AWS_ACCESS_KEY=test_access_key # must not be real key
       - AWS_SECRET_KEY=test_secret_key # must not be real key
       - AWS_REGION=ap-​northeast-1

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
 	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	google.golang.org/api v0.47.0
 	google.golang.org/genproto v0.0.0-20210603172842-58e84a565dcf // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.27.0
 	gopkg.in/yaml.v2 v2.3.0 // indirect


### PR DESCRIPTION
# 背景
腹持ちのサービスアカウントファイルを参照する方法は本番環境では難しい。
GitHub上で管理できないためDockerfileのCOPYは不可。

# 解決
サービスアカウントファイルの情報を一行の文字列にして、それを環境変数で読み込むようにした。